### PR TITLE
Tracking with Google Analytics added

### DIFF
--- a/lib/gtag.tsx
+++ b/lib/gtag.tsx
@@ -1,0 +1,41 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import React from "react";
+
+const GA_TRACKING_ID = "UA-155577261-1";
+
+export const SetupGoogleAnalytics = () => (
+  <>
+    <script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`} />
+    <script
+      dangerouslySetInnerHTML={{
+        __html: `
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', '${GA_TRACKING_ID}');`,
+      }}
+    />
+  </>
+);
+
+declare global {
+  interface Window {
+    gtag: Gtag.Gtag;
+  }
+}
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+export const pageview = (url: string) => {
+  window.gtag("config", GA_TRACKING_ID, {
+    page_path: url,
+  });
+};
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/events
+export const event = ({ action, category, label, value }) => {
+  window.gtag("event", action, {
+    event_category: category,
+    event_label: label,
+    value: value,
+  });
+};

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-dom": "^16.12.0"
   },
   "devDependencies": {
+    "@types/gtag.js": "^0.0.3",
     "@types/node": "^13.1.1",
     "@types/react": "^16.9.17",
     "@types/react-dom": "^16.9.4",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import Head from "next/head";
 import { NextComponentType } from "next";
+import Router from "next/router";
+import { pageview } from "../lib/gtag";
 
 type Props = {
   Component: NextComponentType;
@@ -17,5 +19,7 @@ const MyApp = ({ Component, pageProps }: Props) => {
     </>
   );
 };
+
+Router.events.on("routeChangeComplete", url => pageview(url));
 
 export default MyApp;

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,11 +1,14 @@
 import React from "react";
 import Document, { Html, Head, Main, NextScript } from "next/document";
 
+import { SetupGoogleAnalytics } from "../lib/gtag";
+
 class MyDocument extends Document {
   render() {
     return (
       <Html>
         <Head>
+          <SetupGoogleAnalytics />
           <link rel="stylesheet" href="/foundation.min.css" />
           <style jsx global>{`
             a {

--- a/yarn.lock
+++ b/yarn.lock
@@ -884,6 +884,11 @@
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
+"@types/gtag.js@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@types/gtag.js/-/gtag.js-0.0.3.tgz#bbc414030b2143fc7874260ab825aac82c42928e"
+  integrity sha512-iRF/4Q3G1t0OTNMjK52tpGSQPgEsYzWQL1IdVXt9BywK6MUK3ypB7LaoEQa8sW9gPXENoU1xAyCxqJhMkB2rCA==
+
 "@types/json-schema@^7.0.3":
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"


### PR DESCRIPTION
Based on https://github.com/zeit/next.js/tree/canary/examples/with-google-analytics/